### PR TITLE
Use custom dark theme

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -23,7 +23,7 @@ class MyApp extends StatelessWidget {
       // ),
       home: AppPageView(),
       debugShowCheckedModeBanner: false,
-      darkTheme: ThemeData.dark(),
+      darkTheme: AppThemes.dark,
       theme: AppThemes.light,
       localizationsDelegates: [
         const AppLocalizationDelegate(),


### PR DESCRIPTION
When migrating to Flutter 3, I used the default dark theme while debugging and forgot to revert to the custom theme for dark mode.